### PR TITLE
Only get vars from .env

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,13 @@
 const dotenv = require('dotenv');
 
 module.exports = (filterPrefix = 'SAPPER_APP_', targetPrefix = 'process.env.', excluded = [], dotEnvOptions) => {
-    dotenv.config(dotEnvOptions);
+    const result = dotenv.config(dotEnvOptions);
+    if (result.error) {
+      throw result.error;
+    }
+    
     const SAPPER_APP_ENV_VARS = {};
-    for (let key in process.env) {
+    for (let key in result.parsed) {
         if (key.includes(filterPrefix) && !excluded.includes(key)) SAPPER_APP_ENV_VARS[targetPrefix + key] = ("'" + process.env[key] + "'");
     }
     return SAPPER_APP_ENV_VARS;


### PR DESCRIPTION
This way it won't parse through the rest of the process envs but only the ones that we have in our .env file.